### PR TITLE
Pk2m 180/docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+COPY docker-entrypoint.sh /scripts/docker-entrypoint.sh
+COPY . /concierge_scheduler
+RUN ["chmod", "+x", "/scripts/docker-entrypoint.sh"]
+RUN pip install pyzabbix
+RUN pip install google-auth
+RUN pip install google-cloud-storage
+ENTRYPOINT ["/scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Set the following environment variables in the docker-compose.yml file for the Z
 
 `ZBX_API_HOST`: The Zabbix web frontend endpoint \
 `ZBX_API_USER`: A Zabbix username to access the web API \
-`ZBX_API_PASS`: Password for the above Zabbix username \
+`ZBX_API_PASS`: Password for the above Zabbix username, or absolute path to password file \
 `ZBX_CONFIG_DIR`: The source path for the Zabbix backup/export files \
 `ZBX_TLS_VERIFY`: `'true'` to enable ssl verification (default), `'false'` to disable \
 `ZBX_FORCE_TEMPLATES`: Will delete all templates in destination zabbix server before importing configuration. 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,40 @@ Actions known to the scheduler include the following:
     Given a component (e.g: consul) which needs to be scaled down, functions `pre_pem_file` and `generate_pem_file` construct certificates from the inventory of a component dummy host containing the relevant data and call function `scale_down` with the current number of containers for the component (`current_scale`) and the number we want to reduce (`decrement`). Once the component is decremented to the desired scale the certificates will be deleted.
 
 6. **upload**: this action will upload files in specified config directory to a cloud storage location. Defaults to using GCP Cloud Storage. 
-    
-### Individual Use
+
+## Image Use
+To perform actions using the `concierge_scheduler` image, the required environment variables must be set, 
+and actions performed using command below. **Note**: Actions will be performed in order `b`->`r`->`u`->`d` 
+regardless of command combination order (e.g. `-bud` will be performed in same order as `-dub`)
+* `-b`: run `backup_config`
+* `-r`: run `restore_config`
+* `-u`: run `upload`
+* `-d`: delete `ZBX_CONFIG_DIR` (after running other commands)  
+
+### Examples
+Using `docker run` to perform restore_config:
+```shell
+docker create -e ZBX_CONFIG_DIR=/config-dir --env-file .env-file mesoform/concierge_scheduler -r
+```
+Using `docker-compose.yml` to perform backup_config, then upload to cloud :
+```yaml
+service:
+  concierge_scheduler:
+    image: mesoform/concierge_scheduler
+    env-file: 
+       - .env-file
+    environment:
+       - ZBX_CONFIG_DIR=/config-dir
+    command: ["-bu"]
+```
+
+## Individual Use
 The scheduler can be used outside the concierge paradigm to perform Zabbix configuration import/exports. 
-This will require the `pyzabbix` library.  
+Some external libraries are required performing actions:
+* `pyzabbix`: Required for Zabbix API usage
+* (Optional) `google-auth`: Required for authentication with GCP 
+* (Optional) `google-cloud-storage`: Required for uploading files to GCS
+
 Backing up existing zabbix configuration:
 ```bash
 export ZBX_CONFIG_DIR=/zbx-config/

--- a/concierge_scheduler/concierge_scheduler.py
+++ b/concierge_scheduler/concierge_scheduler.py
@@ -213,6 +213,14 @@ def __log_error_and_fail(message, *args):
     sys.exit(-1)
 
 
+def process_password():
+    password = ZBX_API_PASS
+    if os.path.isfile(ZBX_API_PASS):
+        with open(ZBX_API_PASS, 'r') as f:
+            password = f.readline().strip()
+    return password
+
+
 def initiate_zabbix_client():
     """
     create an instance of Zabbix API client
@@ -221,7 +229,7 @@ def initiate_zabbix_client():
     __info('Logging in using url={} ...', ZBX_API_HOST)
     client = ZabbixAPI(ZBX_API_HOST)
     client.session.verify = False if ZBX_TLS_VERIFY == 'false' else True
-    client.login(user=ZBX_API_USER, password=ZBX_API_PASS)
+    client.login(user=ZBX_API_USER, password=process_password())
     __info('Connected to Zabbix API Version {}', client.api_version())
     return client
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+BACKUP=false
+RESTORE=false
+UPLOAD=false
+DELETE=false
+while getopts brud flag
+do
+    case "${flag}" in
+        b) BACKUP=true;;
+        r) RESTORE=true;;
+        u) UPLOAD=true;;
+        d) DELETE=true;;
+    esac
+done
+
+DATE=$( date '+%Y%m%d%H%M' )
+export ZBX_CONFIG_DIR=${ZBX_CONFIG_DIR:-"/zbx-configs/$DATE"}
+
+
+if [ $BACKUP == true ]; then
+  echo "$( date -u '+%F %T') INFO: Backing up Zabbix configuration to $ZBX_CONFIG_DIR"
+  if python /concierge_scheduler/concierge_scheduler/concierge_scheduler.py event backup_config; then
+    echo "$( date -u '+%F %T') INFO: Zabbix configuration backed up."
+  else
+    echo "$( date -u '+%F %T') ERROR: Failed to backup Zabbix configuration"
+    exit 1
+  fi
+fi
+if [ $RESTORE == true ]; then
+  echo "$( date -u '+%F %T') INFO: Restoring Zabbix configuration from $ZBX_CONFIG_DIR"
+  if python /concierge_scheduler/concierge_scheduler/concierge_scheduler.py event backup_config; then
+    echo "$( date -u '+%F %T') INFO: Restored configuration to $ZBX_API_HOST"
+  else
+    echo "$( date -u '+%F %T') ERROR: Failed to restore zabbix configuration"
+    exit 1
+  fi
+fi
+if [ $UPLOAD == true ]; then
+  echo "$( date -u '+%F %T') INFO: Uploading $ZBX_CONFIG_DIR to cloud"
+  if python /concierge_scheduler/concierge_scheduler/concierge_scheduler.py cloud upload; then
+    echo "$( date -u '+%F %T') INFO: Uploaded to cloud"
+  else
+    echo "$( date -u '+%F %T') ERROR: Failed to upload to cloud"
+    exit 1
+  fi
+fi
+if [ $DELETE == true ]; then
+  echo "$( date -u '+%F %T') INFO: Deleting $ZBX_CONFIG_DIR"
+  rm -r "$ZBX_CONFIG_DIR"
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ $BACKUP == true ]; then
 fi
 if [ $RESTORE == true ]; then
   echo "$( date -u '+%F %T') INFO: Restoring Zabbix configuration from $ZBX_CONFIG_DIR"
-  if python /concierge_scheduler/concierge_scheduler/concierge_scheduler.py event backup_config; then
+  if python /concierge_scheduler/concierge_scheduler/concierge_scheduler.py event restore_config; then
     echo "$( date -u '+%F %T') INFO: Restored configuration to $ZBX_API_HOST"
   else
     echo "$( date -u '+%F %T') ERROR: Failed to restore zabbix configuration"


### PR DESCRIPTION
* `ZBX_API_PASS` can now be a string or a path to a file containing the password
* Added `Dockerfile` for creating concierge_scheduler image from repo, with required libraries, and an entrypoint of `docker-entrypoint.sh`
* `Docker-entrypoint.sh` takes in arguments `-b` `-r` `-u` and `-d` to perform backup, restore, upload or delete operations. 