### PR TITLE
TLS verification errors

### DIFF
--- a/concierge_scheduler/concierge_scheduler.py
+++ b/concierge_scheduler/concierge_scheduler.py
@@ -13,6 +13,7 @@ from pyzabbix import ZabbixAPI
 from concierge_docker import DockerAdmin
 from concierge_zabbix import ZabbixAdmin
 from concierge_gcs import GCSBackup
+
 __DEFAULT_CONFIG_DIR = os.getenv('ZBX_CONFIG_DIR') or os.path.abspath(__file__)
 STORAGE_LOCATION = os.getenv('STORAGE_LOCATION', '')
 STORAGE_FOLDER = os.getenv('STORAGE_FOLDER', '')
@@ -237,6 +238,9 @@ def initiate_zabbix_client():
         __warn('TLS Verification disabled, HTTPS requests to host are unverified')
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         if ZBX_API_HOST.startswith('https'):
+            # TODO: detect_version is set to false to avoid SSL errors before authentication.
+            #  Issue with pyzabbix https://github.com/lukecyca/pyzabbix/issues/157 is pending release.
+            #  After new release, detect_version can be removed from this code
             detect_version = False
     client = ZabbixAPI(ZBX_API_HOST, detect_version=detect_version)
     client.session.verify = tls_verify

--- a/concierge_scheduler/concierge_scheduler.py
+++ b/concierge_scheduler/concierge_scheduler.py
@@ -8,11 +8,11 @@ import os
 import sys
 import logging
 import argparse
+import urllib3
 from pyzabbix import ZabbixAPI
 from concierge_docker import DockerAdmin
 from concierge_zabbix import ZabbixAdmin
 from concierge_gcs import GCSBackup
-
 __DEFAULT_CONFIG_DIR = os.getenv('ZBX_CONFIG_DIR') or os.path.abspath(__file__)
 STORAGE_LOCATION = os.getenv('STORAGE_LOCATION', '')
 STORAGE_FOLDER = os.getenv('STORAGE_FOLDER', '')
@@ -228,7 +228,9 @@ def initiate_zabbix_client():
     """
     __info('Logging in using url={} ...', ZBX_API_HOST)
     client = ZabbixAPI(ZBX_API_HOST)
-    client.session.verify = False if ZBX_TLS_VERIFY == 'false' else True
+    if ZBX_TLS_VERIFY == 'false':
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        client.session.verify = False
     client.login(user=ZBX_API_USER, password=process_password())
     __info('Connected to Zabbix API Version {}', client.api_version())
     return client

--- a/concierge_scheduler/concierge_scheduler.py
+++ b/concierge_scheduler/concierge_scheduler.py
@@ -208,6 +208,10 @@ def __info(message, *args):
     __LOG.log(logging.INFO, message.format(*args))
 
 
+def __warn(message, *args):
+    __LOG.log(logging.WARN, message.format(*args))
+
+
 def __log_error_and_fail(message, *args):
     __LOG.log(logging.ERROR, message.format(*args))
     sys.exit(-1)
@@ -227,10 +231,15 @@ def initiate_zabbix_client():
     :return: object
     """
     __info('Logging in using url={} ...', ZBX_API_HOST)
-    client = ZabbixAPI(ZBX_API_HOST)
-    if ZBX_TLS_VERIFY == 'false':
+    tls_verify = ZBX_TLS_VERIFY.lower() != 'false'
+    detect_version = True
+    if not tls_verify:
+        __warn('TLS Verification disabled, HTTPS requests to host are unverified')
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        client.session.verify = False
+        if ZBX_API_HOST.startswith('https'):
+            detect_version = False
+    client = ZabbixAPI(ZBX_API_HOST, detect_version=detect_version)
+    client.session.verify = tls_verify
     client.login(user=ZBX_API_USER, password=process_password())
     __info('Connected to Zabbix API Version {}', client.api_version())
     return client


### PR DESCRIPTION
Issues with connecting to host despite TLS verification being set to disabled.
* pyzabbix library detects zabbix version on init, so if using invalid certs it will error before login, to avoid this need to set `detect_version` to false.
* Changed logic so that if TLS verification is disabled, and the host begins with "https", `detect_version` will be set to false.
* Disabled `InsecureRequestWarning` and instead did one warning for this on init of the client. 